### PR TITLE
Updating Registerer::registerInstance to support dynamically set Variant properties on Container

### DIFF
--- a/tests/Rox/Core/Register/RegistererTests.php
+++ b/tests/Rox/Core/Register/RegistererTests.php
@@ -40,9 +40,10 @@ class RegistererTests extends RoxTestCase
 
         $registerer->registerInstance($container, "ns1");
 
-        $this->assertEquals(count($flagRepo->getAllFlags()), 4);
+        $this->assertEquals(count($flagRepo->getAllFlags()), 5);
 
         $this->assertEquals($flagRepo->getFlag("ns1.variant1")->getDefaultValue(), "1");
+        $this->assertEquals($flagRepo->getFlag("ns1.variant2")->getDefaultValue(), "6");
         $this->assertEquals($flagRepo->getFlag("ns1.flag1")->getDefaultValue(), "false");
     }
 
@@ -54,9 +55,10 @@ class RegistererTests extends RoxTestCase
 
         $registerer->registerInstance($container, "");
 
-        $this->assertEquals(count($flagRepo->getAllFlags()), 4);
+        $this->assertEquals(count($flagRepo->getAllFlags()), 5);
 
         $this->assertEquals($flagRepo->getFlag("variant1")->getDefaultValue(), "1");
+        $this->assertEquals($flagRepo->getFlag("variant2")->getDefaultValue(), "6");
         $this->assertEquals($flagRepo->getFlag("flag1")->getDefaultValue(), "false");
     }
 }

--- a/tests/Rox/Core/Register/TestContainer.php
+++ b/tests/Rox/Core/Register/TestContainer.php
@@ -21,6 +21,7 @@ class TestContainer implements RoxContainerInterface
     public function __construct()
     {
         $this->variant1 = new Variant("1", ["1", "2", "3"]);
+        $this->variant2 = new Variant("6", ["4", "5", "6"]);
         $this->flag1 = new Flag();
         $this->flag2 = new Flag();
         $this->flag3 = new Flag();


### PR DESCRIPTION
Hi, my company is a new user of this SDK. I've found that while the SDK works well in most use cases, I ran into this issue when trying to set feature flags dynamically from a configuration file (which allows it to be decoupled from the setup code and set at runtime if desired).

I want to be able to read in a configuration from some source, which contains a list of variants, and dynamically set these as properties on the Container so they can be used throughout our application logic. However, the current implementation requires us to "hardcode" the variant names in the constructor as properties, since `ReflectionClass::getProperties()` does not include dynamically-set properties (those without a public/protected/private declaration) in the resulting array.

To fix this, I am refactoring the `registerInstance` function to also get properties from `get_object_vars()` which includes those which are dynamically set. When combined with the current `ReflectionClass` logic, it's able to provide a full list of properties on the container class. I've updated the tests to include an example of this in use.

All unit tests related to the modified class continue to pass when I ran them.