### PR TITLE
Don't use getmypid() in distinct_id generation.

### DIFF
--- a/src/Rox/Server/Client/ServerProperties.php
+++ b/src/Rox/Server/Client/ServerProperties.php
@@ -30,7 +30,6 @@ class ServerProperties extends DeviceProperties
                 getmygid(),
                 get_current_user(),
                 getmyinode(),
-                getmypid(),
                 getlastmod()
             ]));
     }


### PR DESCRIPTION
For those running PHP script in a separate process all the time, it may be confusing that the total
time of calling Rox::setup() is relatively high. This is because it doesn't use cache for config HTTP call
with distinct_id parameter included into it (process id is always different, so the distinct_id).

It wasn't affecting long-running PHP processes like php-fpm or php-cgi. So it's actually a minor case.

FIXME: maybe find some better way of generating or getting distinct id? Another possible way is using unique machine id. On Windows it's stored in registry, and on Linux it's in /var/lib/dbus/machine-id. It's also possible to read it from /etc/hostid on FreeBSD and from registry on MacOS. BUT reading something from registry or filesystem takes time, so might not be the best alternative.