### PR TITLE
Updates environment mode resolver not relying on $_ENV existence

### DIFF
--- a/src/Rox/Core/Client/DeviceProperties.php
+++ b/src/Rox/Core/Client/DeviceProperties.php
@@ -74,9 +74,7 @@ class DeviceProperties implements DevicePropertiesInterface
      */
     function getRolloutEnvironment()
     {
-        $env = isset($_ENV[Environment::ENV_VAR_NAME])
-            ? $_ENV[Environment::ENV_VAR_NAME]
-            : null;
+        $env = Environment::getEnvMode();
         if ($env != Environment::QA && $env != Environment::LOCAL) {
             return Environment::PRODUCTION;
         }

--- a/src/Rox/Core/Consts/Environment.php
+++ b/src/Rox/Core/Consts/Environment.php
@@ -23,7 +23,7 @@ class Environment
      */
     public static function getCdnPath()
     {
-        $env = isset($_ENV[self::ENV_VAR_NAME]) ? $_ENV[self::ENV_VAR_NAME] : null;
+        $env = self::getEnvMode();
         if ($env == self::QA) {
             return 'https://qa-conf.rollout.io';
         } else if ($env == self::LOCAL) {
@@ -37,7 +37,7 @@ class Environment
      */
     public static function getApiPath()
     {
-        $env = isset($_ENV[self::ENV_VAR_NAME]) ? $_ENV[self::ENV_VAR_NAME] : null;
+        $env = self::getEnvMode();
         if ($env == self::QA) {
             return 'https://qax.rollout.io/device/get_configuration';
         } else if ($env == self::LOCAL) {
@@ -51,7 +51,7 @@ class Environment
      */
     public static function getStateCdnPath()
     {
-        $env = isset($_ENV[self::ENV_VAR_NAME]) ? $_ENV[self::ENV_VAR_NAME] : null;
+        $env = self::getEnvMode();
         if ($env == self::QA) {
             return 'https://qa-statestore.rollout.io';
         } else if ($env == self::LOCAL) {
@@ -65,7 +65,7 @@ class Environment
      */
     public static function getStateApiPath()
     {
-        $env = isset($_ENV[self::ENV_VAR_NAME]) ? $_ENV[self::ENV_VAR_NAME] : null;
+        $env = self::getEnvMode();
         if ($env == self::QA) {
             return 'https://qax.rollout.io/device/update_state_store';
         } else if ($env == self::LOCAL) {
@@ -80,7 +80,7 @@ class Environment
      */
     public static function getAnalyticsPath()
     {
-        $env = isset($_ENV[self::ENV_VAR_NAME]) ? $_ENV[self::ENV_VAR_NAME] : null;
+        $env = self::getEnvMode();
         if ($env == self::QA) {
             return 'https://qaanalytic.rollout.io';
         } else if ($env == self::LOCAL) {
@@ -94,12 +94,22 @@ class Environment
      */
     public static function getNotificationsPath()
     {
-        $env = isset($_ENV[self::ENV_VAR_NAME]) ? $_ENV[self::ENV_VAR_NAME] : null;
+        $env = self::getEnvMode();
         if ($env == self::QA) {
             return 'https://qax-push.rollout.io/sse';
         } else if ($env == self::LOCAL) {
             return 'http://127.0.0.1:8887/sse';
         }
         return 'https://push.rollout.io/sse';
+    }
+
+    /**
+     * Reads the environment mode from system environment
+     *
+     * @return null|string
+     */
+    public static function getEnvMode(): ?string
+    {
+        return ((string) getenv(self::ENV_VAR_NAME)) ?: null;
     }
 }

--- a/src/Rox/Core/XPack/Analytics/Event.php
+++ b/src/Rox/Core/XPack/Analytics/Event.php
@@ -36,7 +36,7 @@ class Event implements JsonSerializable
     {
         $this->_type = 'IMPRESSION';
         $time = TimeUtils::currentTimeMillis();
-        $ms = isset($_ENV['rox.analytics.ms']) ? $_ENV['rox.analytics.ms'] : null;
+        $ms = getenv('rox.analytics.ms') ?: null ;
         if ($ms) {
             $time = floatval($ms);
         }

--- a/src/Rox/Server/Client/ServerProperties.php
+++ b/src/Rox/Server/Client/ServerProperties.php
@@ -23,9 +23,8 @@ class ServerProperties extends DeviceProperties
         RoxOptionsInterface $roxOptions)
     {
         parent::__construct($sdkSettings, $roxOptions);
-        $this->_distinctId = isset($_ENV[Environment::INSTANCE_ID_ENV_VAR_NAME])
-            ? $_ENV[Environment::INSTANCE_ID_ENV_VAR_NAME]
-            : md5(join('.', [
+        $this->_distinctId = getenv(Environment::INSTANCE_ID_ENV_VAR_NAME)
+            ?: md5(join('.', [
                 getmyuid(),
                 getmygid(),
                 get_current_user(),


### PR DESCRIPTION
## Problem
Depending on `variables_order` in the `php.ini` ([ref](https://www.php.net/manual/en/ini.core.php#ini.variables-order)) the `$_ENV` variable might not exist so the correct `ROLLOUT_MODE` is not resolved

## Solution
Use the `getenv()` [function](https://www.php.net/manual/en/function.getenv.php) to read env variables. The function resolves variables correctly even if `$_ENV` and `$_SERVER` are empty