### PR TITLE
SDP-5644 Allow UUIDs for api keys to support the platform

### DIFF
--- a/src/Rox/Core/Core.php
+++ b/src/Rox/Core/Core.php
@@ -221,11 +221,12 @@ final class Core
     {
         $roxyUrl = ($roxOptions != null) ? $roxOptions->getRoxyURL() : null;
         if ($roxyUrl == null) {
-            $validApiKeyPattern = "/^[a-f\\d]{24}$/i";
+            $mongoApiKeyPattern = "/^[a-f\\d]{24}$/i";
+            $uuidApiKeyPattern = "/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i";
             if (!$sdkSettings->getApiKey()) {
                 throw new InvalidArgumentException("Invalid rollout apikey - must be specified");
             }
-            if (!preg_match($validApiKeyPattern, $sdkSettings->getApiKey())) {
+            if (!preg_match($mongoApiKeyPattern, $sdkSettings->getApiKey()) && !preg_match($uuidApiKeyPattern, $sdkSettings->getApiKey())) {
                 throw new InvalidArgumentException("Illegal rollout apikey");
             }
         }


### PR DESCRIPTION
<!-- Updated by issuebot -->
![image](https://cloudbees.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium) [SDP-5644: PHP to support app_key as UUID](https://cloudbees.atlassian.net/browse/SDP-5644)
<!-- End of issuebot update -->
to support the new cloudbees platform
