### PR TITLE
[CBP-6097] - return proper array for custom properties serialization

### DIFF
--- a/src/Rox/Core/XPack/Network/StateSender.php
+++ b/src/Rox/Core/XPack/Network/StateSender.php
@@ -169,17 +169,14 @@ class StateSender
         $mapped = array_map(function ($key) use ($allCustomProperties) {
             $value = (string) $allCustomProperties[$key];
 
-            if (!$this->_isCBP && $allCustomProperties[$key]->getType()->getExternalType() === "DateTime") {
-                return null;
-            }
-
             return json_decode($value, true);
         }, $keys);
 
-        return array_filter($mapped, function ($v) {
-            return $v !== null;
+        $mapped = array_filter($mapped, function ($v) {
+            return !(!$this->_isCBP && $v['externalType'] === "DateTime");
         });
 
+        return array_values($mapped);
     }
 
 

--- a/src/Rox/Core/XPack/Network/StateSender.php
+++ b/src/Rox/Core/XPack/Network/StateSender.php
@@ -172,9 +172,11 @@ class StateSender
             return json_decode($value, true);
         }, $keys);
 
-        $mapped = array_filter($mapped, function ($v) {
-            return !(!$this->_isCBP && $v['externalType'] === "DateTime");
-        });
+        if (!$this->_isCBP) {
+            $mapped = array_filter($mapped, function ($v) {
+                return $v['externalType'] !== "DateTime";
+            });
+        }
 
         return array_values($mapped);
     }


### PR DESCRIPTION
<!-- Updated by issuebot -->
![image](https://cloudbees.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium) [CBP-6097: php sdk v 6.0 has increased latency from v5.0.3](https://cloudbees.atlassian.net/browse/CBP-6097)
<!-- End of issuebot update -->
This is fixing the problem of custom properties serialization encoded in json as `{"0"=>{"name:" "....", ....}}` instead of json array `[{"name:" "....", ....}]`